### PR TITLE
Modify shutdown to always destroy infra

### DIFF
--- a/.github/workflows/stop.yml
+++ b/.github/workflows/stop.yml
@@ -77,8 +77,8 @@ jobs:
       run: |
         mkdir -p palworld/Pal/Saved/SaveGames
         mkdir -p palworld/Pal/Saved/Config/LinuxServer
-        rsync -ur -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/Pal/Saved/SaveGames/ palworld/Pal/Saved/SaveGames/
-        rsync -u -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/Pal/Saved/Config/LinuxServer/GameUserSettings.ini palworld/Pal/Saved/Config/LinuxServer/
+        rsync -ur -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/Pal/Saved/SaveGames/ palworld/Pal/Saved/SaveGames/ --ignore-missing-args
+        rsync -u -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/Pal/Saved/Config/LinuxServer/GameUserSettings.ini palworld/Pal/Saved/Config/LinuxServer/ --ignore-missing-args
 
 #ENSHROUDED
 

--- a/.github/workflows/stop.yml
+++ b/.github/workflows/stop.yml
@@ -74,29 +74,6 @@ jobs:
       run: |
         ssh -o "StrictHostKeyChecking=no" -i ./Docker/id_rsa ubuntu@${{ env.TF_VAR_instance_ip }} '/opt/backup.sh'
     
-# #PALWORLD
-
-#     - name: Place game files
-#       if: env.TF_VAR_game == 'palworld'
-#       run: |
-#         mkdir -p palworld/Pal/Saved/SaveGames
-#         mkdir -p palworld/Pal/Saved/Config/LinuxServer
-#         rsync -ur -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/Pal/Saved/SaveGames/ palworld/Pal/Saved/SaveGames/ --ignore-missing-args
-#         rsync -u -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/Pal/Saved/Config/LinuxServer/GameUserSettings.ini palworld/Pal/Saved/Config/LinuxServer/ --ignore-missing-args
-
-# #ENSHROUDED
-
-#     - name: Place game files
-#       if: env.TF_VAR_game == 'enshrouded'
-#       run: |
-#         mkdir -p enshrouded
-#         rsync -ur -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/ enshrouded/
-
-#     - name: Copy game files to S3
-#       run: |
-#         aws s3 sync ./${{ env.TF_VAR_game }} s3://game-files-maximumpigs/${{ env.TF_VAR_environment }}/${{ env.TF_VAR_game }}/
-#         rm -r ${{ env.TF_VAR_game }}
-
     # Destroys AWS infra
     - name: Terraform Destroy AWS
       if: always()

--- a/.github/workflows/stop.yml
+++ b/.github/workflows/stop.yml
@@ -70,7 +70,7 @@ jobs:
         chmod 0400 ../Docker/id_rsa
         echo "TF_VAR_instance_ip=$(terraform output instance_ip | sed 's/"//g')" >> $GITHUB_ENV
 
-    - name: Run backup command on instance
+    - name: Run backup script on instance
       run: |
         ssh -o "StrictHostKeyChecking=no" -i ./Docker/id_rsa ubuntu@${{ env.TF_VAR_instance_ip }} '/opt/backup.sh'
     
@@ -99,13 +99,14 @@ jobs:
 
     # Destroys AWS infra
     - name: Terraform Destroy AWS
+      if: always()
       id: AWS_Destroy
       working-directory: ./Infra
       run: terraform destroy -auto-approve
 
     - name: Discord Webhook Action
-      if: github.ref == 'refs/heads/main'
+      if: always()
       uses: tsickert/discord-webhook@v5.3.0
       with:
-        webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+        webhook-url: ${{ github.ref == 'refs/heads/main' && secrets.DISCORD_WEBHOOK || ' '}}
         content: "${{ env.TF_VAR_game }} server is offline now. Bye"      

--- a/.github/workflows/stop.yml
+++ b/.github/workflows/stop.yml
@@ -70,28 +70,32 @@ jobs:
         chmod 0400 ../Docker/id_rsa
         echo "TF_VAR_instance_ip=$(terraform output instance_ip | sed 's/"//g')" >> $GITHUB_ENV
 
-#PALWORLD
-
-    - name: Place game files
-      if: env.TF_VAR_game == 'palworld'
+    - name: Run backup command on instance
       run: |
-        mkdir -p palworld/Pal/Saved/SaveGames
-        mkdir -p palworld/Pal/Saved/Config/LinuxServer
-        rsync -ur -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/Pal/Saved/SaveGames/ palworld/Pal/Saved/SaveGames/ --ignore-missing-args
-        rsync -u -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/Pal/Saved/Config/LinuxServer/GameUserSettings.ini palworld/Pal/Saved/Config/LinuxServer/ --ignore-missing-args
+        ssh -o "StrictHostKeyChecking=no" -i ./Docker/id_rsa ubuntu@${{ env.TF_VAR_instance_ip }} '/opt/backup.sh'
+    
+# #PALWORLD
 
-#ENSHROUDED
+#     - name: Place game files
+#       if: env.TF_VAR_game == 'palworld'
+#       run: |
+#         mkdir -p palworld/Pal/Saved/SaveGames
+#         mkdir -p palworld/Pal/Saved/Config/LinuxServer
+#         rsync -ur -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/Pal/Saved/SaveGames/ palworld/Pal/Saved/SaveGames/ --ignore-missing-args
+#         rsync -u -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/Pal/Saved/Config/LinuxServer/GameUserSettings.ini palworld/Pal/Saved/Config/LinuxServer/ --ignore-missing-args
 
-    - name: Place game files
-      if: env.TF_VAR_game == 'enshrouded'
-      run: |
-        mkdir -p enshrouded
-        rsync -ur -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/ enshrouded/
+# #ENSHROUDED
 
-    - name: Copy game files to S3
-      run: |
-        aws s3 sync ./${{ env.TF_VAR_game }} s3://game-files-maximumpigs/${{ env.TF_VAR_environment }}/${{ env.TF_VAR_game }}/
-        rm -r ${{ env.TF_VAR_game }}
+#     - name: Place game files
+#       if: env.TF_VAR_game == 'enshrouded'
+#       run: |
+#         mkdir -p enshrouded
+#         rsync -ur -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/ enshrouded/
+
+#     - name: Copy game files to S3
+#       run: |
+#         aws s3 sync ./${{ env.TF_VAR_game }} s3://game-files-maximumpigs/${{ env.TF_VAR_environment }}/${{ env.TF_VAR_game }}/
+#         rm -r ${{ env.TF_VAR_game }}
 
     # Destroys AWS infra
     - name: Terraform Destroy AWS

--- a/.github/workflows/store.yml
+++ b/.github/workflows/store.yml
@@ -71,28 +71,32 @@ jobs:
         echo "TF_VAR_instance_ip=$(terraform output instance_ip | sed 's/"//g')" >> $GITHUB_ENV     
         echo "PRICE=$(terraform state pull |  curl -s -X POST -H "Content-Type: application/json" -d @- https://cost.modules.tf/ | cut -d' ' -f2 | cut -d',' -f1 )" >> $GITHUB_ENV
 
-#PALWORLD
-
-    - name: Place game files
-      if: env.TF_VAR_game == 'palworld'
+    - name: Run backup command on instance
       run: |
-        mkdir -p palworld/Pal/Saved/SaveGames
-        mkdir -p palworld/Pal/Saved/Config/LinuxServer
-        rsync -ur -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/Pal/Saved/SaveGames/ palworld/Pal/Saved/SaveGames/
-        rsync -u -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/Pal/Saved/Config/LinuxServer/GameUserSettings.ini palworld/Pal/Saved/Config/LinuxServer/
+        ssh -o "StrictHostKeyChecking=no" -i ./Docker/id_rsa ubuntu@${{ env.TF_VAR_instance_ip }} '/opt/backup.sh'
 
-#ENSHROUDED
+# #PALWORLD
 
-    - name: Place game files
-      if: env.TF_VAR_game == 'enshrouded'
-      run: |
-        mkdir -p enshrouded
-        rsync -ur -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/ enshrouded/
+#     - name: Place game files
+#       if: env.TF_VAR_game == 'palworld'
+#       run: |
+#         mkdir -p palworld/Pal/Saved/SaveGames
+#         mkdir -p palworld/Pal/Saved/Config/LinuxServer
+#         rsync -ur -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/Pal/Saved/SaveGames/ palworld/Pal/Saved/SaveGames/
+#         rsync -u -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/Pal/Saved/Config/LinuxServer/GameUserSettings.ini palworld/Pal/Saved/Config/LinuxServer/
 
-    - name: Copy game files to S3
-      run: |
-        aws s3 sync ./${{ env.TF_VAR_game }} s3://game-files-maximumpigs/${{ env.TF_VAR_environment }}/${{ env.TF_VAR_game }}/
-        rm -r ${{ env.TF_VAR_game }}
+# #ENSHROUDED
+
+#     - name: Place game files
+#       if: env.TF_VAR_game == 'enshrouded'
+#       run: |
+#         mkdir -p enshrouded
+#         rsync -ur -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/ enshrouded/
+
+#     - name: Copy game files to S3
+#       run: |
+#         aws s3 sync ./${{ env.TF_VAR_game }} s3://game-files-maximumpigs/${{ env.TF_VAR_environment }}/${{ env.TF_VAR_game }}/
+#         rm -r ${{ env.TF_VAR_game }}
 
     - name: Discord Webhook Action
       if: github.ref == 'refs/heads/main'

--- a/.github/workflows/store.yml
+++ b/.github/workflows/store.yml
@@ -75,29 +75,6 @@ jobs:
       run: |
         ssh -o "StrictHostKeyChecking=no" -i ./Docker/id_rsa ubuntu@${{ env.TF_VAR_instance_ip }} '/opt/backup.sh'
 
-# #PALWORLD
-
-#     - name: Place game files
-#       if: env.TF_VAR_game == 'palworld'
-#       run: |
-#         mkdir -p palworld/Pal/Saved/SaveGames
-#         mkdir -p palworld/Pal/Saved/Config/LinuxServer
-#         rsync -ur -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/Pal/Saved/SaveGames/ palworld/Pal/Saved/SaveGames/
-#         rsync -u -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/Pal/Saved/Config/LinuxServer/GameUserSettings.ini palworld/Pal/Saved/Config/LinuxServer/
-
-# #ENSHROUDED
-
-#     - name: Place game files
-#       if: env.TF_VAR_game == 'enshrouded'
-#       run: |
-#         mkdir -p enshrouded
-#         rsync -ur -e "ssh -o StrictHostKeyChecking=no -i ./Docker/id_rsa" ubuntu@${{ env.TF_VAR_instance_ip }}:/data/ enshrouded/
-
-#     - name: Copy game files to S3
-#       run: |
-#         aws s3 sync ./${{ env.TF_VAR_game }} s3://game-files-maximumpigs/${{ env.TF_VAR_environment }}/${{ env.TF_VAR_game }}/
-#         rm -r ${{ env.TF_VAR_game }}
-
     - name: Discord Webhook Action
       if: github.ref == 'refs/heads/main'
       uses: tsickert/discord-webhook@v5.3.0

--- a/.github/workflows/store.yml
+++ b/.github/workflows/store.yml
@@ -71,7 +71,7 @@ jobs:
         echo "TF_VAR_instance_ip=$(terraform output instance_ip | sed 's/"//g')" >> $GITHUB_ENV     
         echo "PRICE=$(terraform state pull |  curl -s -X POST -H "Content-Type: application/json" -d @- https://cost.modules.tf/ | cut -d' ' -f2 | cut -d',' -f1 )" >> $GITHUB_ENV
 
-    - name: Run backup command on instance
+    - name: Run backup script on instance
       run: |
         ssh -o "StrictHostKeyChecking=no" -i ./Docker/id_rsa ubuntu@${{ env.TF_VAR_instance_ip }} '/opt/backup.sh'
 

--- a/Infra/cloudinit/userdata.tmpl
+++ b/Infra/cloudinit/userdata.tmpl
@@ -57,21 +57,6 @@ write_files:
       */10 * * * * ubuntu /opt/backup.sh
     append: true
 
-  - path: /etc/init.d/s3_backup
-    permissions: '0755'
-    content: |
-      #! /bin/bash
-
-      for dir in ${save_dirs};
-      do
-        /usr/bin/aws s3 cp /data/$dir s3://game-files-maximumpigs/${environment}/${game}/$dir --recursive;
-      done
-
-      for file in ${save_files};
-      do
-        /usr/bin/aws s3 cp /data/$file s3://game-files-maximumpigs/${environment}/${game}/$file;
-      done
-
 runcmd:
   - mkdir /data
   - /usr/bin/aws s3 sync s3://game-files-maximumpigs/${environment}/${game}/ /data/
@@ -81,4 +66,3 @@ runcmd:
   - chmod 600 /swapfile0
   - mkswap /swapfile0
   - swapon /swapfile0
-  - ln -s /etc/init.d/s3_backup /etc/rc0.d/K02s3bak

--- a/Infra/cloudinit/userdata.tmpl
+++ b/Infra/cloudinit/userdata.tmpl
@@ -37,7 +37,7 @@ system_info:
 write_files:
 
   - path: /opt/backup.sh
-    permissions: '0770'
+    permissions: '0755'
     content: |
       #! /bin/bash
 
@@ -57,6 +57,21 @@ write_files:
       */10 * * * * ubuntu /opt/backup.sh
     append: true
 
+  - path: /etc/init.d/s3_backup
+    permissions: '0755'
+    content: |
+      #! /bin/bash
+
+      for dir in ${save_dirs};
+      do
+        /usr/bin/aws s3 cp /data/$dir s3://game-files-maximumpigs/${environment}/${game}/$dir --recursive;
+      done
+
+      for file in ${save_files};
+      do
+        /usr/bin/aws s3 cp /data/$file s3://game-files-maximumpigs/${environment}/${game}/$file;
+      done
+
 runcmd:
   - mkdir /data
   - chmod -R 777 /data
@@ -66,3 +81,4 @@ runcmd:
   - chmod 600 /swapfile0
   - mkswap /swapfile0
   - swapon /swapfile0
+  - ln /etc/init.d/s3_backup /etc/rc0.d/K02s3bak

--- a/Infra/cloudinit/userdata.tmpl
+++ b/Infra/cloudinit/userdata.tmpl
@@ -62,7 +62,7 @@ runcmd:
   - chmod -R 777 /data
   - chown root:ubuntu /opt/backup.sh
   - /usr/bin/aws s3 sync s3://game-files-maximumpigs/${environment}/${game}/ /data/
-  - dd if=/dev/zero of=/swapfile0 bs=1024 count=2097152
+  - dd if=/dev/zero of=/swapfile0 bs=1024 count=$( expr ${swap_size} \* 1024 \* 1024 )
   - chmod 600 /swapfile0
   - mkswap /swapfile0
   - swapon /swapfile0

--- a/Infra/cloudinit/userdata.tmpl
+++ b/Infra/cloudinit/userdata.tmpl
@@ -53,7 +53,7 @@ write_files:
 
   - path: /etc/crontab
     content: |
-      * */3 * * * ubuntu /usr/bin/docker restart palworld 2>/dev/null
+      0 */3 * * * ubuntu /usr/bin/docker restart palworld 2>/dev/null
       */10 * * * * ubuntu /opt/backup.sh
     append: true
 
@@ -74,11 +74,11 @@ write_files:
 
 runcmd:
   - mkdir /data
-  - chmod -R 777 /data
-  - chown root:ubuntu /opt/backup.sh
   - /usr/bin/aws s3 sync s3://game-files-maximumpigs/${environment}/${game}/ /data/
+  - chown root:docker /data --recursive
+  - chown root:ubuntu /opt/backup.sh
   - dd if=/dev/zero of=/swapfile0 bs=1024 count=$( expr ${swap_size} \* 1024 \* 1024 )
   - chmod 600 /swapfile0
   - mkswap /swapfile0
   - swapon /swapfile0
-  - ln /etc/init.d/s3_backup /etc/rc0.d/K02s3bak
+  - ln -s /etc/init.d/s3_backup /etc/rc0.d/K02s3bak

--- a/Infra/cloudinit/userdata.tmpl
+++ b/Infra/cloudinit/userdata.tmpl
@@ -61,6 +61,7 @@ runcmd:
   - mkdir /data
   - /usr/bin/aws s3 sync s3://game-files-maximumpigs/${environment}/${game}/ /data/
   - chown root:docker /data --recursive
+  - chmod 775 /data --recursive
   - chown root:ubuntu /opt/backup.sh
   - dd if=/dev/zero of=/swapfile0 bs=1024 count=$( expr ${swap_size} \* 1024 \* 1024 )
   - chmod 600 /swapfile0

--- a/Infra/locals.tf
+++ b/Infra/locals.tf
@@ -3,7 +3,8 @@ locals {
     palworld = {
       name      = "palworld"
       vm_size   = "m6a.large"
-      disk_size = "18"
+      disk_size = "20"
+      swap_size = "4"
       # Directory path containing save files relative to container mount root. Will backup and restore all contents recursively. Separate multiple values by space. If left blank whole /data folder will be backed up.
       save_dirs = "Pal/Saved/SaveGames/"
       # Single save file path relative to container mount root. Will backup and restore these single files. Separate multiple values by space.
@@ -21,6 +22,7 @@ locals {
       name      = "enshrouded"
       vm_size   = "m6a.large"
       disk_size = "44"
+      swap_size = "4"
       # Directory path containing save files relative to container mount root. Will backup and restore all contents recursively. Separate multiple values by space. If left blank whole /data folder will be backed up.
       save_dirs = ""
       # Single save file path relative to container mount root. Will backup and restore these single files. Separate multiple values by space.

--- a/Infra/main.tf
+++ b/Infra/main.tf
@@ -27,6 +27,7 @@ resource "aws_instance" "my_instance" {
     game        = var.game
     environment = var.environment
     save_dirs   = local.games[var.game].save_dirs,
-    save_files  = local.games[var.game].save_files
+    save_files  = local.games[var.game].save_files,
+    swap_size   = local.games[var.game].swap_size
   }))
 }


### PR DESCRIPTION
Sometimes the server becomes unresponsive and destroy action fails.
This will at least allow the destroy action to continue on un-contactable server so it can be restarted.